### PR TITLE
Add check_xmpp_feature

### DIFF
--- a/plugins/check_xmpp_feature
+++ b/plugins/check_xmpp_feature
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+host_jid=$1
+service_feature=$2
+
+curl \
+        --silent \
+        --show-error \
+        --fail \
+        "http://localhost:1337/check_feature?target=$host_jid&feature=$service_feature" \
+    || exit 2


### PR DESCRIPTION
This was a long one-liner located in the nagios commands file.  It
was too messy to duplicate it in the icinga2 commands config, so it
has been broken out into its own plugin script. UP-1927