### PR TITLE
check_certs: fix notafter time parsing

### DIFF
--- a/plugins/check_certs.py
+++ b/plugins/check_certs.py
@@ -122,7 +122,7 @@ for fname in files:
 
         mykey = crypto.load_certificate(crypto.FILETYPE_PEM, mybuf)
         cn = mykey.get_subject().commonName
-        notafter = datetime.strptime(mykey.get_notAfter(), "%Y%m%d%H%M%SZ")
+        notafter = datetime.strptime(mykey.get_notAfter().decode(), "%Y%m%d%H%M%SZ")
         diff = notafter - today
         days = diff.days
         if days <= options.critical:


### PR DESCRIPTION
I don't know how this worked before, but there's this error:

/usr/lib/nagios-mendix/plugins/check_certs.py -w 31 -c 7
Traceback (most recent call last):
  File "/usr/lib/nagios-mendix/plugins/check_certs.py", line 125, in <module>
      notafter = datetime.strptime(mykey.get_notAfter(), "%Y%m%d%H%M%SZ")
      TypeError: strptime() argument 1 must be str, not bytes